### PR TITLE
Fix for error message around duplicate properties/descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ New features:
 - Support for custom pseudo-classes and pseudo-elements via the `PseudoClass` and `PseudoElement` constructors nsaunders/purescript-tecton#38
 
 Bugfixes:
+- Fixed the content of the compiler error that results from duplicate properties or descriptors within a single ruleset. Previously all values were incorrectly reported as having the type `CommonKeyword`. nsaunders/purescript-tecton#39
 
 Other improvements:
 

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -1229,7 +1229,7 @@ instance
 else instance
   ( IsSymbol p
   , Declaration p v
-  , Row.Cons p CommonKeyword () p'
+  , Row.Cons p v () p'
   ) =>
   Assoc p v Declaration' p' where
   assoc _ v =
@@ -1241,7 +1241,7 @@ else instance
 instance
   ( IsSymbol d
   , FontFaceDeclaration d v
-  , Row.Cons d CommonKeyword () d'
+  , Row.Cons d v () d'
   ) =>
   Assoc d v FontFaceDeclaration' d' where
   assoc _ v =


### PR DESCRIPTION
### Description

This fixes the content of the error message that arises from duplicate properties or descriptors within a single ruleset.

For example, given this ruleset...

```purescript
universal ? Rule.do
  width := nil
  width := nil -- Note the duplicate `width` property.
```

...the error currently reads as...

```
  Could not match type
           
    ( ... )
           
  with type
                          
    ( width :: CommonKeyword
    ...                   
    )  
```

After this change, it will read as...

```
  Could not match type
           
    ( ... )
           
  with type
                          
    ( width :: Measure Nil
    ...                   
    )  
```

...reflecting the real type of the property value.

### Design considerations

N/A

### Future plans

N/A

### References

N/A

### Code change checklist

- [x] Any new or updated functionality includes corresponding unit test coverage.
- [x] I have verified code formatting, run the unit tests, and checked for any changes in the examples.
- [x] I have added an entry to the _Unreleased_ section of the CHANGELOG.
